### PR TITLE
updates logSearch url

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -31,7 +31,7 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -2,8 +2,6 @@ mountpoints:
   /:
     url: https://adobe.sharepoint.com/:f:/r/sites/search-seo/Shared%20Documents/website
 
-    # adding a comment in order to test helix bot within dev branch
-
 folders:
   /express/templates/: /express/templates/default
   /br/express/templates/: /br/express/templates/default

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -2,6 +2,8 @@ mountpoints:
   /:
     url: https://adobe.sharepoint.com/:f:/r/sites/search-seo/Shared%20Documents/website
 
+    # adding a comment in order to test helix bot within dev branch
+
 folders:
   /express/templates/: /express/templates/default
   /br/express/templates/: /br/express/templates/default


### PR DESCRIPTION
Describe your specific features or fixes

Adds in an updated SharePoint link for the logSearch function, which will populate SharePoint search-terms-log sheet with user search queries on the express page.

Test URLs:
- Before: https://dev--express-seo--albrooks-ad.hlx.page/express/templates/
- After: https://main--express-seo--albrooks-ad.hlx.page/express/templates/
