### PR TITLE
updates logSearch url in templates list

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -31,7 +31,7 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-function logSearch(form, url = 'https://dev--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -31,7 +31,7 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = '../search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -31,7 +31,7 @@ function handlelize(str) {
     .toLowerCase(); // To lowercase
 }
 
-function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://dev--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -495,7 +495,7 @@ function getRedirectUrl(tasks, topics, format, allTemplatesMetadata) {
   }
 }
 
-function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = '../search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -495,7 +495,7 @@ function getRedirectUrl(tasks, topics, format, allTemplatesMetadata) {
   }
 }
 
-function logSearch(form, url = 'https://dev--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -495,7 +495,7 @@ function getRedirectUrl(tasks, topics, format, allTemplatesMetadata) {
   }
 }
 
-function logSearch(form, url = 'https://main--express-website--adobe.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -495,7 +495,7 @@ function getRedirectUrl(tasks, topics, format, allTemplatesMetadata) {
   }
 }
 
-function logSearch(form, url = 'https://main--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
+function logSearch(form, url = 'https://dev--express-seo--albrooks-ad.hlx.page/express/search-terms-log') {
   if (form) {
     const input = form.querySelector('input');
     fetch(url, {


### PR DESCRIPTION
Describe your specific features or fixes

Updates the logSearch function's default url so that the SEO team's SharePoint will update with live queries.

Test URLs:
- Before: https://dev--express-seo--albrooks-ad.hlx.page/express/templates/
- After: https://main--express-seo--albrooks-ad.hlx.page/express/templates/
